### PR TITLE
Updated EEML

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Name and Link|Location|Organiser|Dates|Deadline|Fee|Aid (Travel Grants etc)
 [Deep Learning and Reinforcement Learning Summer School (DLRL 2020)](https://dlrlsummerschool.ca)|Montreal, Canada|CIFAR, MILA|July 29 - Aug 6|Feb 22|($700.00 - $1900.00)CAD|Limited financial support is available for students/postdocs
 [International Summer School on Deep Learning (DeepLearn 2020)](http://deeplearn2020.irdta.eu/)|León, Guanajuato, Mexico|IRDTA|July 27 - July 31|Dec 29 (Early) to On-site|€310-€550|No
 [Machine learning summer school in healthcare and biosciences](https://bumblekite.four-corp.com/)|ETH Zürich, Switzerland|Bumblekite|July 19 – July 28|March 15|$600-$2,900|Limited number of full and partial scholarships.
-[Eastern European Machine Learning Summer School](https://www.eeml.eu)|Krakow, Poland|EEML Team|July 6 - July 11|March 20|€100-€300|Based on financial considerations
+[Eastern European Machine Learning Summer School](https://www.eeml.eu)| Online |EEML Team|July 6 - July 11|April 20|Free | Based on financial considerations
 [Machine Learning Summer School (MLSS Tübingen)](http://mlss.tuebingen.mpg.de/2020)|Tübingen, Germany|[Max Planck Institute for Intelligent Systems](https://www.is.mpg.de/)|June 28 - July 10|Feb 11|€280-€800|Full & partial travel awards for strong applications.|
 [AI and Games Summer School](https://school.gameaibook.org/)|Copenhagen, Denmark|[modl.ai](https://modl.ai/)|June 22-26|NA|€435~€935|NA|
 [North Africa Middle East Summer School (NASSMA 2020 Istanbul)](http://nassma-ml.org)|Istanbul, Turkey| NASSMA Team -  ITU |June 22-27|March 20|€200-€1000|Full/partial travel grants based on financial considerations for students.|


### PR DESCRIPTION
> Taking into account the COVID-19 situation, we have decided that EEML will go virtual this year. We will extend the application deadline until April 20. The application details remain the same. Registration will be free for all accepted candidates! We are saddened to drop the physical presence, but we are investigating virtual options to make sure the school continues to be a fun and informative experience! 
