### PR TITLE
Please add Winter School on Deep Learning (WSDL 2023)

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ NOTE:
 ## 2022 Summer Schools
 Name and Link|Location|Organiser|Dates|Deadline|Fee|Aid (Travel Grants etc)| Notes
 ------|--|---|----|--|-|-|----
-[2nd Winter School on Deep Learning from Perceptrons to Diffusion Models (WSDL 2023)](https://sites.google.com/view/wsdl2023/)|Kolkata, India|ECSU, Indian Statistical Institute, Kolkata|6th January 2023 - 4th March 2023| 25th December 2023| [Fee](https://sites.google.com/view/wsdl2023/apply)| | Its an online schools. The inaugural lecture will be by [Prof. Geoffrey E. Hinton](https://www.cs.toronto.edu/~hinton/).
+[2nd Winter School on Deep Learning from Perceptrons to Diffusion Models (WSDL 2023)](https://sites.google.com/view/wsdl2023/)|Kolkata, India|[ECSU, Indian Statistical Institute, Kolkata](https://oldweb.isical.ac.in/~ecsu/)|6th January 2023 - 4th March 2023| 25th December 2023| [Fee](https://sites.google.com/view/wsdl2023/apply)| | Its an online schools. The inaugural lecture will be by [Prof. Geoffrey E. Hinton](https://www.cs.toronto.edu/~hinton/).
 [6th International Summer School on Resource-Aware Machine Learning (REAML 2022)](https://sfb876.tu-dortmund.de/summer-school-2022)|Dortmund, Germany|CRC 876 and AI group at TU Dortmund University| September 12-16|August 14|Early registration fee: EUR 420, Late registration fee: EUR 520| Yes||
 [Mediterranean Machine Learning  Summer School](https://www.m2lschool.org/)|Milan, Italy|AI Education Foundation| September 12-16|April 1|Students: free, Post-doc and faculty: 100€, Industry: 200€| Yes||
 [eXplainable AI Summer School](https://xaiss.eu/)|Delft, Netherlands|L3S Research Center & TU Delft|August 29 - September 02|N/A|400€ incl. VAT (19%)|N/A|4 ECTS credits can be earned. Registrations are limited to 70 people in total.

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ NOTE:
 ## 2022 Summer Schools
 Name and Link|Location|Organiser|Dates|Deadline|Fee|Aid (Travel Grants etc)| Notes
 ------|--|---|----|--|-|-|----
+[2nd Winter School on Deep Learning from Perceptrons to Diffusion Models (WSDL 2023)](https://sites.google.com/view/wsdl2023/)|Kolkata, India|ECSU, Indian Statistical Institute, Kolkata|6th January 2023 - 4th March 2023| 25th December 2023| [Fee](https://sites.google.com/view/wsdl2023/apply)| | Its an online schools. The inaugural lecture will be by [Prof. Geoffrey E. Hinton](https://www.cs.toronto.edu/~hinton/).
 [6th International Summer School on Resource-Aware Machine Learning (REAML 2022)](https://sfb876.tu-dortmund.de/summer-school-2022)|Dortmund, Germany|CRC 876 and AI group at TU Dortmund University| September 12-16|August 14|Early registration fee: EUR 420, Late registration fee: EUR 520| Yes||
 [Mediterranean Machine Learning  Summer School](https://www.m2lschool.org/)|Milan, Italy|AI Education Foundation| September 12-16|April 1|Students: free, Post-doc and faculty: 100€, Industry: 200€| Yes||
 [eXplainable AI Summer School](https://xaiss.eu/)|Delft, Netherlands|L3S Research Center & TU Delft|August 29 - September 02|N/A|400€ incl. VAT (19%)|N/A|4 ECTS credits can be earned. Registrations are limited to 70 people in total.


### PR DESCRIPTION
The ECSU unit of [Indian Statistical Institute, Kolkata](https://www.linkedin.com/company/indian-statistical-institute-kol/) will carry on their yearly tradition with another chapter of [Winter School on Deep Learning](https://www.linkedin.com/company/winter-school-on-deep-learning/). This will be a fully online weekend only hands-on focused school for students and professionals. This year we have 8 of the very best scientists with us as plenary speakers. They will be joined by faculties and researchers from ISI, IITs, Stanford University, UC Berkeley, Amazon, NIH, and many more. 